### PR TITLE
Allow usage of lists and children objects

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 env:
-    publicRelease: "${{ github.ref == 'refs/heads/main' && 'True' || 'False' }}"
+    publicRelease: "${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}"
     configuration: "${{ github.ref == 'refs/heads/main' && 'Release' || 'Debug' }}"
 
 jobs:
@@ -29,14 +29,14 @@ jobs:
     - name: Test
       run: dotnet test --configuration $configuration --no-restore --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
     - name: Package NuGet
-      if: ${{ env.publicRelease }}
+      if: env.publicRelease == true
       run: dotnet pack --no-restore --no-build --configuration $configuration -o packages
     - name: Set package version
-      if: ${{ env.publicRelease }}
+      if: env.publicRelease == true
       id: setPackageVersion
       run: echo "::set-output name=packageVersion::$BUILD_VERSION"
     - uses: actions/upload-artifact@v3
-      if: ${{ env.publicRelease }}
+      if: env.publicRelease == true
       with:
         name: packages-drop
         path: |
@@ -45,16 +45,15 @@ jobs:
   nuget-release:
     runs-on: ubuntu-latest
     needs: build
+    if: env.publicRelease == true
     steps:
     - uses: actions/download-artifact@v3
-      if: ${{ env.publicRelease }}
       with:
         name: packages-drop
         path: packages
     - name: Display structure of downloaded files
       run: ls -R
     - uses: actions/setup-dotnet@v1.7.2
-      if: ${{ env.publicRelease }}
     - name: Publish NuGet Package
       run: dotnet nuget push packages/Hic.Mustache.MSBuild.${{ needs.build.outputs.packageVersion }}.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
 

--- a/src/Mustache.MSBuild/InputParser.cs
+++ b/src/Mustache.MSBuild/InputParser.cs
@@ -1,5 +1,7 @@
 namespace Mustache.MSBuild;
 
+using System.Text.Json;
+
 internal class InputParser
 {
     public static IDictionary<string, object> Parse(string inputData)
@@ -23,5 +25,48 @@ internal class InputParser
         }
 
         return dict;
+    }
+
+    public static Dictionary<string, object> RecursiveDeserialize(Dictionary<string, object> rootDictionary)
+    {
+        var dictionary = new Dictionary<string, object>(rootDictionary.Count);
+        foreach (var keyValuePair in rootDictionary)
+        {
+            if (keyValuePair.Value is JsonElement element)
+            {
+                dictionary[keyValuePair.Key] = ParseElement(element);
+            }
+        }
+
+        return dictionary;
+    }
+
+    private static object ParseElement(JsonElement element)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Array:
+                var list = JsonSerializer.Deserialize<List<object>>(element.ToString());
+
+                var newList = new List<object>(list.Count);
+
+                foreach (var listElement in list)
+                {
+                    if (listElement is JsonElement jsonElement)
+                    {
+                        newList.Add(ParseElement(jsonElement));
+                    }
+                    else
+                    {
+                        newList.Add(listElement);
+                    }
+                }
+
+                return newList;
+            case JsonValueKind.Object:
+                return RecursiveDeserialize(JsonSerializer.Deserialize<Dictionary<string, object>>(element.ToString()));
+            default:
+                return element;
+        }
     }
 }

--- a/src/Mustache.MSBuild/InputParser.cs
+++ b/src/Mustache.MSBuild/InputParser.cs
@@ -48,23 +48,29 @@ internal class InputParser
             case JsonValueKind.Array:
                 var list = JsonSerializer.Deserialize<List<object>>(element.ToString());
 
-                var newList = new List<object>(list.Count);
-
-                foreach (var listElement in list)
+                if (list != null)
                 {
-                    if (listElement is JsonElement jsonElement)
+                    var newList = new List<object>(list.Count);
+
+                    foreach (var listElement in list)
                     {
-                        newList.Add(ParseElement(jsonElement));
+                        if (listElement is JsonElement jsonElement)
+                        {
+                            newList.Add(ParseElement(jsonElement));
+                        }
+                        else
+                        {
+                            newList.Add(listElement);
+                        }
                     }
-                    else
-                    {
-                        newList.Add(listElement);
-                    }
+
+                    return newList;
                 }
 
-                return newList;
+                throw new InvalidOperationException();
+
             case JsonValueKind.Object:
-                return RecursiveDeserialize(JsonSerializer.Deserialize<Dictionary<string, object>>(element.ToString()));
+                return RecursiveDeserialize(JsonSerializer.Deserialize<Dictionary<string, object>>(element.ToString()) ?? throw new InvalidOperationException());
             default:
                 return element;
         }

--- a/src/Mustache.MSBuild/MustacheDirectoryExpand.cs
+++ b/src/Mustache.MSBuild/MustacheDirectoryExpand.cs
@@ -51,7 +51,7 @@ public class MustacheDirectoryExpand : Microsoft.Build.Utilities.Task
         }
 
         using var dataStream = File.OpenRead(rootDataFile);
-        var rootDict = JsonSerializer.Deserialize<Dictionary<string, object>>(dataStream);
+        var rootDict = InputParser.RecursiveDeserialize(JsonSerializer.Deserialize<Dictionary<string, object>>(dataStream));
 
         // Parse the input data and merge it with the root data dictionary. Giving precedence to the input data.
         var inputDictionary = InputParser.Parse(this.InputData);
@@ -100,7 +100,7 @@ public class MustacheDirectoryExpand : Microsoft.Build.Utilities.Task
         if (File.Exists(dataFile))
         {
             using var dataStream = File.OpenRead(dataFile);
-            var data = JsonSerializer.Deserialize<Dictionary<string, object>>(dataStream);
+            var data = InputParser.RecursiveDeserialize(JsonSerializer.Deserialize<Dictionary<string, object>>(dataStream));
             if (data != null)
             {
                 mergedData = data.Concat(parentData.Where(x => !data.ContainsKey(x.Key)));

--- a/src/Mustache.MSBuild/MustacheDirectoryExpand.cs
+++ b/src/Mustache.MSBuild/MustacheDirectoryExpand.cs
@@ -51,7 +51,8 @@ public class MustacheDirectoryExpand : Microsoft.Build.Utilities.Task
         }
 
         using var dataStream = File.OpenRead(rootDataFile);
-        var rootDict = InputParser.RecursiveDeserialize(JsonSerializer.Deserialize<Dictionary<string, object>>(dataStream));
+        var rootDict =
+            InputParser.RecursiveDeserialize(JsonSerializer.Deserialize<Dictionary<string, object>>(dataStream) ?? throw new InvalidOperationException());
 
         // Parse the input data and merge it with the root data dictionary. Giving precedence to the input data.
         var inputDictionary = InputParser.Parse(this.InputData);
@@ -95,12 +96,13 @@ public class MustacheDirectoryExpand : Microsoft.Build.Utilities.Task
             parentData = this.rootData;
         }
 
-        var mergedData = parentData.Select(kv => kv);
+        var mergedData = (parentData ?? throw new InvalidOperationException()).Select(kv => kv);
         var dataFile = Path.Combine(this.DataRootDirectory, node.GetIdentifierChain(), this.DefaultDataFileName);
         if (File.Exists(dataFile))
         {
             using var dataStream = File.OpenRead(dataFile);
-            var data = InputParser.RecursiveDeserialize(JsonSerializer.Deserialize<Dictionary<string, object>>(dataStream));
+            var data =
+                InputParser.RecursiveDeserialize(JsonSerializer.Deserialize<Dictionary<string, object>>(dataStream) ?? throw new InvalidOperationException());
             if (data != null)
             {
                 mergedData = data.Concat(parentData.Where(x => !data.ContainsKey(x.Key)));

--- a/src/Mustache.MSBuild/MustacheExpand.cs
+++ b/src/Mustache.MSBuild/MustacheExpand.cs
@@ -24,7 +24,8 @@ public class MustacheExpand : Microsoft.Build.Utilities.Task
     {
         var templateString = File.ReadAllText(this.TemplateFile);
         using var dataStream = File.OpenRead(this.DataFile);
-        var rootDict = JsonSerializer.Deserialize<Dictionary<string, object>>(dataStream);
+        var rootDict =
+            InputParser.RecursiveDeserialize(JsonSerializer.Deserialize<Dictionary<string, object>>(dataStream));
         var inputDictionary = InputParser.Parse(this.InputData);
 
         var mergedDict = new[] { rootDict, inputDictionary }
@@ -36,4 +37,6 @@ public class MustacheExpand : Microsoft.Build.Utilities.Task
         File.WriteAllText(this.DestinationFile, expandedTemplate);
         return true;
     }
+
+
 }

--- a/src/Mustache.MSBuild/MustacheExpand.cs
+++ b/src/Mustache.MSBuild/MustacheExpand.cs
@@ -25,7 +25,7 @@ public class MustacheExpand : Microsoft.Build.Utilities.Task
         var templateString = File.ReadAllText(this.TemplateFile);
         using var dataStream = File.OpenRead(this.DataFile);
         var rootDict =
-            InputParser.RecursiveDeserialize(JsonSerializer.Deserialize<Dictionary<string, object>>(dataStream));
+            InputParser.RecursiveDeserialize(JsonSerializer.Deserialize<Dictionary<string, object>>(dataStream) ?? throw new InvalidOperationException());
         var inputDictionary = InputParser.Parse(this.InputData);
 
         var mergedDict = new[] { rootDict, inputDictionary }
@@ -37,6 +37,4 @@ public class MustacheExpand : Microsoft.Build.Utilities.Task
         File.WriteAllText(this.DestinationFile, expandedTemplate);
         return true;
     }
-
-
 }

--- a/tests/Mustache.MSBuild.Tests/Mustache.MSBuild.Tests.csproj
+++ b/tests/Mustache.MSBuild.Tests/Mustache.MSBuild.Tests.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <None Include="data/**/*.*" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="expected_results/**/*.*" CopyToOutputDirectory="PreserveNewest" />
     <None Include="mustache-templates/*.mustache" CopyToOutputDirectory="PreserveNewest" />
     <None Include="data-directory-structure.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/tests/Mustache.MSBuild.Tests/MustacheExpandTests.cs
+++ b/tests/Mustache.MSBuild.Tests/MustacheExpandTests.cs
@@ -71,6 +71,28 @@ public class MustacheExpandTests
         Assert.False(string.IsNullOrEmpty(item?.Name), "Expected name to be non-empty");
         Assert.Equal("Override", item?.Name);
     }
+
+    [Fact]
+    public void Execute_Array_Success()
+    {
+        var task = new MustacheExpand
+        {
+            BuildEngine = this.buildEngineMock.Object,
+            TemplateFile = "mustache-templates/array.mustache",
+            DataFile = "data/array.json",
+            DestinationFile = "result.html",
+        };
+
+        var result = task.Execute();
+
+        var actual = File.ReadAllText(task.DestinationFile);
+        var expected = File.ReadAllText("expected_results/array.html");
+
+        Assert.True(result);
+        Assert.NotNull(actual);
+        Assert.NotNull(expected);
+        Assert.Equal(expected, actual);
+    }
 }
 
 public class SimpleItem

--- a/tests/Mustache.MSBuild.Tests/data/array.json
+++ b/tests/Mustache.MSBuild.Tests/data/array.json
@@ -3,5 +3,10 @@
     { "name": "resque" },
     { "name": "hub" },
     { "name": "rip" }
+  ],
+  "implicitIterator": [
+    "resque",
+    "hub",
+    "rip"
   ]
 }

--- a/tests/Mustache.MSBuild.Tests/data/array.json
+++ b/tests/Mustache.MSBuild.Tests/data/array.json
@@ -1,0 +1,7 @@
+{
+  "list": [
+    { "name": "resque" },
+    { "name": "hub" },
+    { "name": "rip" }
+  ]
+}

--- a/tests/Mustache.MSBuild.Tests/expected_results/array.html
+++ b/tests/Mustache.MSBuild.Tests/expected_results/array.html
@@ -2,3 +2,7 @@ Hello world!
 <b>resque</b>
 <b>hub</b>
 <b>rip</b>
+
+<b>resque</b>
+<b>hub</b>
+<b>rip</b>

--- a/tests/Mustache.MSBuild.Tests/expected_results/array.html
+++ b/tests/Mustache.MSBuild.Tests/expected_results/array.html
@@ -1,0 +1,4 @@
+Hello world!
+<b>resque</b>
+<b>hub</b>
+<b>rip</b>

--- a/tests/Mustache.MSBuild.Tests/mustache-templates/array.mustache
+++ b/tests/Mustache.MSBuild.Tests/mustache-templates/array.mustache
@@ -2,3 +2,7 @@ Hello world!
 {{#list}}
 <b>{{name}}</b>
 {{/list}}
+
+{{#implicitIterator}}
+<b>{{.}}</b>
+{{/implicitIterator}}

--- a/tests/Mustache.MSBuild.Tests/mustache-templates/array.mustache
+++ b/tests/Mustache.MSBuild.Tests/mustache-templates/array.mustache
@@ -1,0 +1,4 @@
+Hello world!
+{{#list}}
+<b>{{name}}</b>
+{{/list}}


### PR DESCRIPTION
The mustache lib required the JSON files to be parsed recursively, as it did could not handle JsonElements of kind Object or Array.