### PR TITLE
Fix github workflow and update actions

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -43,9 +43,9 @@ jobs:
           packages/*.nupkg
 
   nuget-release:
+    if: ${{ github.ref == 'refs/heads/main' && true || false }} # can't use env in this context, so need to re evaluate
     runs-on: ubuntu-latest
     needs: build
-    if: env.publicRelease == true
     steps:
     - uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -16,11 +16,11 @@ jobs:
     outputs:
       packageVersion: ${{ steps.setPackageVersion.outputs.packageVersion }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1.7.2
+      uses: actions/setup-dotnet@v3
 
     - name: Install dependencies
       run: dotnet restore
@@ -53,7 +53,7 @@ jobs:
         path: packages
     - name: Display structure of downloaded files
       run: ls -R
-    - uses: actions/setup-dotnet@v1.7.2
+    - uses: actions/setup-dotnet@v3
     - name: Publish NuGet Package
       run: dotnet nuget push packages/Hic.Mustache.MSBuild.${{ needs.build.outputs.packageVersion }}.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
 


### PR DESCRIPTION
Workflows conditions were broken by previous PR.
Conditions now behave as originally wanted:
 - We don't try to publish the nugget if we are not in the main branch

Updated actions as there were warnings about them using node12